### PR TITLE
Fix container name for controller-manager and nclet

### DIFF
--- a/cmd/controller-manager/sub.mk
+++ b/cmd/controller-manager/sub.mk
@@ -1,4 +1,4 @@
-CONTROLLER_MANAGER_IMG ?= proelbtn/netcon-pms-controller-manager:dev
+CONTROLLER_MANAGER_IMG ?= netcon-pms-controller-manager:dev
 
 ##@ Build: Controller Manager
 

--- a/cmd/nclet/sub.mk
+++ b/cmd/nclet/sub.mk
@@ -1,4 +1,4 @@
-NCLET_IMG ?= proelbtn/netcon-pms-nclet:dev
+NCLET_IMG ?= netcon-pms-nclet:dev
 
 ##@ Build: nclet
 

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -8,4 +8,3 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: proelbtn/netcon-pms-controller-manager
+  newName: netcon-pms-controller-manager
   newTag: dev


### PR DESCRIPTION
When I developed problem-management-subsystem alone, I used `proelbtn/` as the prefix of container names. This PR removes this prefix.