### PR TITLE
access-helperのデフォルト値をnetcon仕様にする

### DIFF
--- a/cmd/access-helper/main.go
+++ b/cmd/access-helper/main.go
@@ -60,7 +60,7 @@ func accessNode(
 		return errors.New("node defined, but not working")
 	}
 
-	accessMethod := AccessMethodExec
+	accessMethod := AccessMethodSSH
 	if value, ok := nodeDefinition.Labels[AccessMethodKey]; ok {
 		accessMethod = AccessMethod(value)
 	}

--- a/cmd/nclet/Dockerfile
+++ b/cmd/nclet/Dockerfile
@@ -1,7 +1,5 @@
 # Build the manager binary
 FROM golang:1.19 as builder
-ARG TARGETOS
-ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -23,6 +21,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o nc
 # Build the manager binary
 FROM golang:1.19 as access-helper_builder
 
+ARG DEFAULT_USERNAME
+ARG DEFAULT_PASSWORD
+
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -33,7 +34,8 @@ COPY cmd/access-helper cmd/access-helper
 COPY pkg/ pkg/
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o access-helper ./cmd/access-helper
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 \
+    go build -o access-helper -ldflags="-X main.defaultUsername=${DEFAULT_USERNAME} -X main.defaultPassword=${DEFAULT_PASSWORD}" ./cmd/access-helper
 
 FROM nicolaka/netshoot:v0.7
 WORKDIR /

--- a/cmd/nclet/sub.mk
+++ b/cmd/nclet/sub.mk
@@ -1,10 +1,16 @@
 NCLET_IMG ?= netcon-pms-nclet:dev
 
+DEFAULT_USERNAME ?= username
+DEFAULT_PASSWORD ?= password
+
 ##@ Build: nclet
 
 .PHONY: nclet-docker-build
 nclet-docker-build: test ## Build docker image with the manager.
-	DOCKER_BUILDKIT=1 docker build --file cmd/nclet/Dockerfile -t ${NCLET_IMG} .
+	DOCKER_BUILDKIT=1 docker build --file cmd/nclet/Dockerfile \
+		--build-arg DEFAULT_USERNAME="${DEFAULT_USERNAME}" \
+		--build-arg DEFAULT_PASSWORD="${DEFAULT_PASSWORD}" \
+		-t ${NCLET_IMG} .
 
 .PHONY: nclet-docker-push
 nclet-docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
* SSH接続する際に、defaultUsername, defaultPassword, defaultPortを利用して接続するようになった
* defaultUsername, defaultPasswordをnetcon仕様にできるようにするための変更を加えた
    * make nclet-docker-build DEFAULT_USERNAME=hoge DEFAULT_PASSWORD=fuga

close #45 
