### PR TITLE
cEOSでもSSHでログインできるようにする実装を行った

### DIFF
--- a/cmd/access-helper/ssh.go
+++ b/cmd/access-helper/ssh.go
@@ -75,10 +75,18 @@ func (h *SSHAccessHelper) _access(
 		return 0, err
 	}
 
+	// TODO: change ClientConfig for node kind
 	config := &ssh.ClientConfig{
 		User: userName,
 		Auth: []ssh.AuthMethod{
 			ssh.Password(password),
+			ssh.KeyboardInteractive(func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+				answers := make([]string, len(questions))
+				for i, _ := range answers {
+					answers[i] = password
+				}
+				return answers, nil
+			}),
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}


### PR DESCRIPTION
close #60 

cEOSはpassword認証ではなくkeyboard-interactive認証をしているため、元々のコードではSSHすることができなかった。この変更によって、cEOSにもログインできるようになった。